### PR TITLE
Converting numeric columns to character columns

### DIFF
--- a/TR1/HMDHFDplus/R/HFDutils.R
+++ b/TR1/HMDHFDplus/R/HFDutils.R
@@ -188,6 +188,12 @@ getHFDitemavail <- function(CNTRY){
     X |>
       clean_names() |>
       rename("measure" = .data$x) |> 
+
+      # "Converting Numeric Columns to Character Columns"
+      # e.g., on HFD, item = "tfrRR", 
+      # `census_or_register_based_parity_estimates` is numeric 
+      mutate_if(is.numeric, as.character) |>       
+            
       pivot_longer(-.data$measure,names_to = "subtype",values_to = "years") |> 
       filter(.data$measure != "")
   }


### PR DESCRIPTION
* Added a line to convert numeric columns to character columns.
* On HFD web, `census_or_register_based_parity_estimates` is numeric, which generates an error while importing data from the web.